### PR TITLE
Slightly improve the installation instructions by mentioning the directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Installation
 
  1. Copy the plugin directory into the `plugins` directory
 
- 2. Run bundler
+ 2. Run bundler (from the plugin directory):
 
         $ bundle install
 
- 3. Run rake task
+ 3. Run rake task (from the Redmine root directory):
 
         $ rake emoji
 


### PR DESCRIPTION
At first I ran the rake task from the plugin directory :see_no_evil: - that's why I thought making the directories more clear could help others.

Thanks for this great plugin! :thumbsup:
