### PR TITLE
Prevent deprecation error message

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'gemoji'


### PR DESCRIPTION
The source :rubygems is deprecated because HTTP requests are insecure.
